### PR TITLE
add prefix option and unify file structure

### DIFF
--- a/webshot/src/bin/cli.ts
+++ b/webshot/src/bin/cli.ts
@@ -22,7 +22,8 @@ program
   .command('capture')
   .description('Capture screenshot of a web page')
   .argument('<url>', 'URL of the web page to capture')
-  .option('-o, --output <dir>', 'Output directory for screenshots', './screenshots')
+  .option('-o, --output <dir>', 'Output directory for screenshots (env: WEBSHOT_OUTPUT_DIR)', process.env.WEBSHOT_OUTPUT_DIR || './screenshots')
+  .option('-p, --prefix <prefix>', 'Custom prefix for filenames instead of URL hash (env: WEBSHOT_PREFIX)', process.env.WEBSHOT_PREFIX)
   .option('-w, --width <number>', 'Viewport width', '1280')
   .option('-h, --height <number>', 'Viewport height', '720')
   .option('--no-full-page', 'Capture only visible area instead of full page')
@@ -59,6 +60,7 @@ program
       const captureOptions: CaptureOptionsWithAuth = {
         url,
         outputDir: options.output,
+        prefix: options.prefix,
         viewport: {
           width: parseInt(options.width, 10),
           height: parseInt(options.height, 10)
@@ -82,13 +84,10 @@ program
       await capture.close();
       
       console.log(chalk.green('✅ Screenshot captured successfully!'));
-      console.log(chalk.cyan(`📁 Logs: ${result.logsData.metadata.filename}`));
+      console.log(chalk.cyan(`📁 File: ${result.metadata.filename}`));
       
-      if (result.evidenceData) {
-        console.log(chalk.cyan(`📁 Evidence: ${result.evidenceData.metadata.filename}`));
-        console.log(chalk.yellow(`🔍 Diff: ${result.logsData.metadata.diffPercentage?.toFixed(2)}%`));
-      } else {
-        console.log(chalk.gray('📁 No significant changes detected (evidence not saved)'));
+      if (result.metadata.diffPercentage !== undefined) {
+        console.log(chalk.yellow(`🔍 Diff: ${result.metadata.diffPercentage.toFixed(2)}%`));
       }
       
     } catch (error) {
@@ -152,81 +151,39 @@ program
       console.log(chalk.gray(`Directory: ${path.resolve(outputDir)}`));
       
       try {
-        // Check for new folder structure first
-        const logsDir = path.join(outputDir, 'logs');
-        const evidenceDir = path.join(outputDir, 'evidence');
-        
-        let logFiles: string[] = [];
-        let evidenceFiles: string[] = [];
-        let useFolderStructure = false;
-        
-        try {
-          await fs.access(logsDir);
-          await fs.access(evidenceDir);
-          logFiles = await fs.readdir(logsDir);
-          evidenceFiles = await fs.readdir(evidenceDir);
-          useFolderStructure = true;
-        } catch {
-          // Fallback to old structure
-          const files = await fs.readdir(outputDir);
-          logFiles = files.filter(file => file.endsWith('_logs.json'));
-          evidenceFiles = files.filter(file => file.endsWith('_evidence.json'));
-        }
+        const files = await fs.readdir(outputDir);
+        const jsonFiles = files.filter(file => file.endsWith('.json') && /^[a-zA-Z0-9]+_\d{3}\.json$/.test(file));
         
         if (url) {
           const hash = generateUrlHash(url);
           
-          const filteredLogFiles = logFiles.filter(file => useFolderStructure ? file.startsWith(hash) : file.includes(hash));
-          const filteredEvidenceFiles = evidenceFiles.filter(file => useFolderStructure ? file.startsWith(hash) : file.includes(hash));
+          const filteredFiles = jsonFiles.filter(file => file.startsWith(hash));
           
           console.log(chalk.cyan(`\n🔍 Screenshots for URL: ${url}`));
           console.log(chalk.cyan(`Hash: ${hash}`));
-          console.log(chalk.gray(`Log files found: ${filteredLogFiles.length}`));
-          console.log(chalk.gray(`Evidence files found: ${filteredEvidenceFiles.length}`));
+          console.log(chalk.gray(`Files found: ${filteredFiles.length}`));
           
-          if (useFolderStructure) {
-            console.log(chalk.white('\n📁 Logs folder:'));
-            for (const file of filteredLogFiles.sort()) {
-              console.log(chalk.white(`  - ${file}`));
-            }
-            console.log(chalk.white('\n📁 Evidence folder:'));
-            for (const file of filteredEvidenceFiles.sort()) {
-              console.log(chalk.white(`  - ${file}`));
-            }
-          } else {
-            for (const file of [...filteredLogFiles, ...filteredEvidenceFiles].sort()) {
-              console.log(chalk.white(`  - ${file}`));
-            }
+          for (const file of filteredFiles.sort()) {
+            console.log(chalk.white(`  - ${file}`));
           }
         } else {
-          console.log(chalk.cyan(`\nTotal files:`));
-          console.log(chalk.white(`  - Logs: ${logFiles.length}`));
-          console.log(chalk.white(`  - Evidence: ${evidenceFiles.length}`));
+          console.log(chalk.cyan(`\nTotal files: ${jsonFiles.length}`));
           
-          if (useFolderStructure) {
-            console.log(chalk.cyan('\n📁 Folder structure: logs/ and evidence/'));
-          } else {
-            console.log(chalk.cyan('\n📁 Legacy structure: files with suffixes'));
-          }
-          
-          // ハッシュ別の統計を表示
-          const hashStats = new Map<string, number>();
-          for (const file of logFiles) {
-            let hash: string;
-            if (useFolderStructure) {
-              // New structure: extract hash from filename like c984d06a_timestamp.json
-              hash = file.substring(0, 8);
-            } else {
-              // Old structure: extract hash from filename like hash_sequence_logs.json
-              hash = file.substring(0, 8);
+          // 識別子別の統計を表示
+          const identifierStats = new Map<string, number>();
+          for (const file of jsonFiles) {
+            // ファイル名から識別子を抽出 (identifier_sequence.json)
+            const match = file.match(/^([^_]+)_\d{3}\.json$/);
+            if (match) {
+              const identifier = match[1];
+              identifierStats.set(identifier, (identifierStats.get(identifier) || 0) + 1);
             }
-            hashStats.set(hash, (hashStats.get(hash) || 0) + 1);
           }
           
-          if (hashStats.size > 0) {
-            console.log(chalk.cyan('\n📈 Statistics by URL:'));
-            for (const [hash, count] of hashStats.entries()) {
-              console.log(chalk.white(`  - ${hash}: ${count} screenshots`));
+          if (identifierStats.size > 0) {
+            console.log(chalk.cyan('\n📈 Statistics by identifier:'));
+            for (const [identifier, count] of identifierStats.entries()) {
+              console.log(chalk.white(`  - ${identifier}: ${count} screenshots`));
             }
           }
         }
@@ -245,7 +202,8 @@ program
   .command('interactive')
   .description('Start interactive screenshot mode with browser')
   .argument('<url>', 'URL of the web page to open')
-  .option('-o, --output <dir>', 'Output directory for screenshots', './screenshots')
+  .option('-o, --output <dir>', 'Output directory for screenshots (env: WEBSHOT_OUTPUT_DIR)', process.env.WEBSHOT_OUTPUT_DIR || './screenshots')
+  .option('-p, --prefix <prefix>', 'Custom prefix for filenames instead of URL hash (env: WEBSHOT_PREFIX)', process.env.WEBSHOT_PREFIX)
   .option('-w, --width <number>', 'Viewport width', '1280')
   .option('-h, --height <number>', 'Viewport height', '720')
   .option('--auth-config <path>', 'Path to authentication config file')
@@ -279,6 +237,7 @@ program
 
       const captureOptions: CaptureOptionsWithAuth = {
         url,
+        prefix: options.prefix,
         viewport: {
           width: parseInt(options.width, 10),
           height: parseInt(options.height, 10)

--- a/webshot/src/types/index.ts
+++ b/webshot/src/types/index.ts
@@ -11,7 +11,6 @@ export interface ScreenshotMetadata {
   fullPage: boolean;
   hasDiff?: boolean;
   diffPercentage?: number;
-  logsFilename?: string;
 }
 
 export interface ScreenshotData {
@@ -23,6 +22,7 @@ export interface ScreenshotData {
 export interface CaptureOptions {
   url: string;
   outputDir?: string;
+  prefix?: string; // カスタムプレフィックス（指定時はハッシュの代わりに使用）
   viewport?: {
     width: number;
     height: number;


### PR DESCRIPTION
- Add --prefix option to use custom prefix instead of URL hash
- Support WEBSHOT_OUTPUT_DIR and WEBSHOT_PREFIX environment variables
- Remove logs/evidence folder separation, save all screenshots to single directory
- Use identifier_sequence.json naming pattern (e.g. mysite_001.json)
- Always save screenshots regardless of diff detection
- Update CLI help and README documentation

🤖 Generated with [Claude Code](https://claude.ai/code)